### PR TITLE
fft update

### DIFF
--- a/examples/fft-update-test.py
+++ b/examples/fft-update-test.py
@@ -1,0 +1,40 @@
+# example for using a user-provided p(k) made with camb
+
+import camb
+import numpy as np
+import jax.numpy as jnp
+import exgaltoolkit.lpt as lpt
+import exgaltoolkit.mockgen as mg
+import exgaltoolkit.util.jax_util as ju
+
+zics=100
+camb_par = camb.set_params(H0=68)
+camb_par.set_matter_power(redshifts=[zics], kmax=2.0)
+camb_wsp = camb.get_results(camb_par)
+
+def my_get_pspec():
+    k, zlist, pk = camb_wsp.get_matter_power_spectrum(
+                  minkh=1e-4, maxkh=1e2, npoints = 2000)
+    ju.distributed_initialize()
+    return {'k': jnp.asarray(k), 'pofk': jnp.asarray(pk[0,:])}
+
+# Create cosmology interface first
+cosmo = mg.CosmologyInterface(pspec=my_get_pspec(),parallel=True)
+
+# create Sky object with the cosmology interface
+mocksky = mg.Sky(cosmo=cosmo, N=128, seed=13579, Niter=1, icw=True)
+
+# now write delta
+mocksky.run(laststep='convolution')
+delta=np.asarray(mocksky.cube.delta)
+
+# create another Sky object with the same cosmology interface
+mocksky = mg.Sky(cosmo=cosmo, N=128, seed=13579, Niter=1, icw=True)
+
+# now write s1x
+mocksky.run(laststep='LPT')
+np.savez("./output/grids",
+         delta=delta,
+         s1x=np.asarray(mocksky.cube.s1x),
+         s1y=np.asarray(mocksky.cube.s1y),
+         s1z=np.asarray(mocksky.cube.s1z))

--- a/exgaltoolkit/lpt/multihost_rfft.py
+++ b/exgaltoolkit/lpt/multihost_rfft.py
@@ -1,68 +1,103 @@
 # Compute real to complex FFTs on GPUs with Jax on multiple GPUs.
-# Adapted from version developed by Lukas Winkler, see:
+# Adapted from example developed by Lukas Winkler:
 #   https://gist.github.com/Findus23/eb5ecb9f65ccf13152cda7c7e521cbdd
+# and jax custom partitioning documentation:
+#   https://jax.readthedocs.io/en/latest/jax.experimental.custom_partitioning.html
 
 from typing import Callable
 
 import jax
 from jax.experimental.custom_partitioning import custom_partitioning
-from jax.sharding import PartitionSpec as P, NamedSharding
-
+from jax.sharding import Mesh, PartitionSpec as P, NamedSharding
+import gc
 
 def fft_partitioner(fft_func: Callable[[jax.Array], jax.Array], partition_spec: P):
     @custom_partitioning
     def func(x):
         return fft_func(x)
 
-    def supported_sharding(sharding, shape):
-        return NamedSharding(sharding.mesh, partition_spec)
+    def partition(mesh, arg_shapes, result_shape):
+        mesh = jax.tree.map(lambda x: x.sharding, arg_shapes)[0].mesh
+        namedsharding = NamedSharding(mesh, partition_spec)
+        return mesh, fft_func, namedsharding, (namedsharding,)
 
-    def partition(arg_shapes, arg_shardings, result_shape, result_sharding):
-        return fft_func, supported_sharding(arg_shardings[0], arg_shapes[0]), (
-            supported_sharding(arg_shardings[0], arg_shapes[0]),)
-
-    def infer_sharding_from_operands(arg_shapes, arg_shardings, shape):
-        return supported_sharding(arg_shardings[0], arg_shapes[0])
+    def infer_sharding_from_operands(mesh, arg_shapes, result_shape):
+        mesh = jax.tree.map(lambda x: x.sharding, arg_shapes)[0].mesh
+        return NamedSharding(mesh, partition_spec)
 
     func.def_partition(
-        infer_sharding_from_operands=infer_sharding_from_operands,
-        partition=partition
+        partition=partition,
+        infer_sharding_from_operands=infer_sharding_from_operands
     )
     return func
-
 
 def _fft_XY(x):
     return jax.numpy.fft.fftn(x, axes=[0, 1])
 
-
 def _fft_Z(x):
     return jax.numpy.fft.rfft(x, axis=2)
-
 
 def _ifft_XY(x):
     return jax.numpy.fft.ifftn(x, axes=[0, 1])
 
-
 def _ifft_Z(x):
     return jax.numpy.fft.irfft(x, axis=2)
-
 
 fft_XY = fft_partitioner(_fft_XY, P(None, None, "gpus"))
 fft_Z = fft_partitioner(_fft_Z, P(None, "gpus"))
 ifft_XY = fft_partitioner(_ifft_XY, P(None, None, "gpus"))
 ifft_Z = fft_partitioner(_ifft_Z, P(None, "gpus"))
 
-
 def rfftn(x):
     x = fft_Z(x)
     x = fft_XY(x)
     return x
-
 
 def irfftn(x):
     x = ifft_XY(x)
     x = ifft_Z(x)
     return x
 
+def fft(x_np,direction='r2c'):
 
+    from jax import jit
+    from jax.experimental import mesh_utils
+    from jax.experimental.multihost_utils import sync_global_devices
 
+    num_gpus = jax.device_count()
+
+    global_shape = (x_np.shape[0],x_np.shape[1]*num_gpus,x_np.shape[2])
+
+    devices = mesh_utils.create_device_mesh((num_gpus,))
+    mesh = Mesh(devices, axis_names=('gpus',))
+    with mesh:
+        x_single = jax.device_put(x_np).block_until_ready()
+        del x_np ; gc.collect()
+        xshard = jax.make_array_from_single_device_arrays(
+            global_shape,
+            NamedSharding(mesh, P(None, "gpus")),
+            [x_single]).block_until_ready()
+        del x_single ; gc.collect()
+        if direction=='r2c':
+            rfftn_jit = jit(
+                rfftn,
+                in_shardings=(NamedSharding(mesh, P(None, "gpus"))),
+                out_shardings=(NamedSharding(mesh, P(None, "gpus")))
+            )
+        else:
+            irfftn_jit = jit(
+                irfftn,
+                in_shardings=(NamedSharding(mesh, P(None, "gpus"))),
+                out_shardings=(NamedSharding(mesh, P(None, "gpus")))
+            )
+        sync_global_devices("wait for compiler output")
+
+        with jax.spmd_mode('allow_all'):
+
+            if direction=='r2c':
+                out_jit: jax.Array = rfftn_jit(xshard).block_until_ready()
+            else:
+                out_jit: jax.Array = irfftn_jit(xshard).block_until_ready()
+            sync_global_devices("loop")
+            local_out_subset = out_jit.addressable_data(0)
+    return local_out_subset


### PR DESCRIPTION
Update the sharded jax FFT to match updated arguments for `jax.experimental.custom_partitioning.custom_partitioning` partition method:
```
def partition(mesh, arg_shapes, result_shape):
```
as in the [latest version](https://docs.jax.dev/en/latest/jax.experimental.custom_partitioning.html). Test with 2 gpus on perlmutter was successful, i.e.:
```
salloc --qos=interactive -N 1 --time=60 -C gpu -A cosmosim --gpus-per-node=2
export XGSMENV_NGPUS=2
[malvarez@nid001188 login (job 38772278)  exgaltoolkit]$ srun -n 2 python examples/fft-update-test.py
WARNING:root:get_matter_power_spectrum using larger k_max than input parameter Transfer.kmax
WARNING:root:get_matter_power_spectrum using larger k_max than input parameter Transfer.kmax

Generating sky for model "MockgenDefaultID" with seed=13579
1.434168 sec for noise generation
3.093979 sec for noise convolution
2.923440 sec for LPT
particle mass: 8.170e+15 Msun
Lbox:          7700.0 Mpc
4.428840 sec for write ICs

Time summary:
  4.42884e+00 per 1 iterations of write ICs
  3.09398e+00 per 1 iterations of noise convolution
  2.92344e+00 per 1 iterations of LPT
  1.43417e+00 per 1 iterations of noise generation

  1.18804e+01 all steps

Generating sky for model "MockgenDefaultID" with seed=13579
0.038856 sec for noise generation
0.226636 sec for noise convolution
1.061911 sec for LPT
particle mass: 8.170e+15 Msun
Lbox:          7700.0 Mpc
1.999245 sec for write ICs

Time summary:
  1.99924e+00 per 1 iterations of write ICs
  1.06191e+00 per 1 iterations of LPT
  2.26636e-01 per 1 iterations of noise convolution
  3.88558e-02 per 1 iterations of noise generation

  3.32665e+00 all steps
```